### PR TITLE
feat: Allow any origin to read images from stream

### DIFF
--- a/include/nadjieb/mjpeg_streamer.hpp
+++ b/include/nadjieb/mjpeg_streamer.hpp
@@ -124,6 +124,7 @@ class MJPEGStreamer : public nadjieb::utils::NonCopyable {
         init_res.setValue("Connection", "close");
         init_res.setValue("Cache-Control", "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0");
         init_res.setValue("Pragma", "no-cache");
+        init_res.setValue("Access-Control-Allow-Origin", "*");
         init_res.setValue("Content-Type", "multipart/x-mixed-replace; boundary=nadjiebmjpegstreamer");
         auto init_res_str = init_res.serialize();
 

--- a/single_include/nadjieb/mjpeg_streamer.hpp
+++ b/single_include/nadjieb/mjpeg_streamer.hpp
@@ -29,7 +29,6 @@ SOFTWARE.
 
 // #include <nadjieb/utils/version.hpp>
 
-
 /// The major version number
 #define NADJIEB_MJPEG_STREAMER_VERSION_MAJOR 3
 
@@ -40,14 +39,14 @@ SOFTWARE.
 #define NADJIEB_MJPEG_STREAMER_VERSION_PATCH 0
 
 /// The complete version number
-#define NADJIEB_MJPEG_STREAMER_VERSION_CODE (NADJIEB_MJPEG_STREAMER_VERSION_MAJOR * 10000 + NADJIEB_MJPEG_STREAMER_VERSION_MINOR * 100 + NADJIEB_MJPEG_STREAMER_VERSION_PATCH)
+#define NADJIEB_MJPEG_STREAMER_VERSION_CODE                                                    \
+    (NADJIEB_MJPEG_STREAMER_VERSION_MAJOR * 10000 + NADJIEB_MJPEG_STREAMER_VERSION_MINOR * 100 \
+     + NADJIEB_MJPEG_STREAMER_VERSION_PATCH)
 
 /// Version number as string
 #define NADJIEB_MJPEG_STREAMER_VERSION_STRING "3.0.0"
 
-
 // #include <nadjieb/net/http_request.hpp>
-
 
 #include <sstream>
 #include <string>
@@ -112,7 +111,6 @@ class HTTPRequest {
 
 // #include <nadjieb/net/http_response.hpp>
 
-
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -156,12 +154,9 @@ class HTTPResponse {
 
 // #include <nadjieb/net/listener.hpp>
 
-
 // #include <nadjieb/net/socket.hpp>
 
-
 // #include <nadjieb/utils/platform.hpp>
-
 
 #if defined _MSC_VER || defined __MINGW32__
 #define NADJIEB_MJPEG_STREAMER_PLATFORM_WINDOWS
@@ -170,7 +165,6 @@ class HTTPResponse {
 #else
 #define NADJIEB_MJPEG_STREAMER_PLATFORM_LINUX
 #endif
-
 
 #ifdef NADJIEB_MJPEG_STREAMER_PLATFORM_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
@@ -339,7 +333,6 @@ static int pollSockets(NADJIEB_MJPEG_STREAMER_POLLFD* fds, size_t nfds, long tim
 
 // #include <nadjieb/utils/non_copyable.hpp>
 
-
 namespace nadjieb {
 namespace utils {
 class NonCopyable {
@@ -358,7 +351,6 @@ class NonCopyable {
 
 // #include <nadjieb/utils/runnable.hpp>
 
-
 namespace nadjieb {
 namespace utils {
 enum class State { UNSPECIFIED = 0, NEW, BOOTING, RUNNING, TERMINATING, TERMINATED };
@@ -373,7 +365,6 @@ class Runnable {
 };
 }  // namespace utils
 }  // namespace nadjieb
-
 
 #include <functional>
 #include <iostream>
@@ -568,14 +559,11 @@ class Listener : public nadjieb::utils::NonCopyable, public nadjieb::utils::Runn
 
 // #include <nadjieb/net/publisher.hpp>
 
-
 // #include <nadjieb/net/socket.hpp>
 
 // #include <nadjieb/net/topic.hpp>
 
-
 // #include <nadjieb/net/socket.hpp>
-
 
 #include <mutex>
 #include <shared_mutex>
@@ -659,7 +647,6 @@ class Topic {
 // #include <nadjieb/utils/non_copyable.hpp>
 
 // #include <nadjieb/utils/runnable.hpp>
-
 
 #include <algorithm>
 #include <condition_variable>
@@ -818,7 +805,6 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
 
 // #include <nadjieb/utils/non_copyable.hpp>
 
-
 #include <string>
 
 namespace nadjieb {
@@ -907,6 +893,7 @@ class MJPEGStreamer : public nadjieb::utils::NonCopyable {
         init_res.setValue("Connection", "close");
         init_res.setValue("Cache-Control", "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0");
         init_res.setValue("Pragma", "no-cache");
+        init_res.setValue("Access-Control-Allow-Origin", "*");
         init_res.setValue("Content-Type", "multipart/x-mixed-replace; boundary=nadjiebmjpegstreamer");
         auto init_res_str = init_res.serialize();
 


### PR DESCRIPTION
Since the frontend code is running on a different port than the stream this is needed to allow the frontend to read and manipulate the imagedata.